### PR TITLE
Version 1.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ sudo: false
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry test $TRAVIS_PHP_VERSION == '7.1' && composer install --no-interaction --prefer-dist --dev scrutinizer/ocular
 
 script:
   - mkdir -p build/tests/
@@ -22,7 +23,7 @@ script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=build/tests/coverage.xml
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION == '5.6' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover build/tests/coverage.xml; fi
+  - if [[ $TRAVIS_PHP_VERSION == '7.1' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover build/tests/coverage.xml; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-dist
-  - travis_retry test $TRAVIS_PHP_VERSION == '7.1' && composer install --no-interaction --prefer-dist --dev scrutinizer/ocular
+  - test $TRAVIS_PHP_VERSION == '7.1' && travis_retry composer install --no-interaction --prefer-dist --dev scrutinizer/ocular
 
 script:
   - mkdir -p build/tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-dist
-  - test $TRAVIS_PHP_VERSION == '7.1' && travis_retry composer require --dev --no-interaction --prefer-dist scrutinizer/ocular
+  - test $TRAVIS_PHP_VERSION == '7.1' && travis_retry composer require --dev --no-interaction --prefer-dist scrutinizer/ocular || true
 
 script:
   - mkdir -p build/tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-dist
-  - test $TRAVIS_PHP_VERSION == '7.1' && travis_retry composer install --no-interaction --prefer-dist --dev scrutinizer/ocular
+  - test $TRAVIS_PHP_VERSION == '7.1' && travis_retry composer require --dev --no-interaction --prefer-dist scrutinizer/ocular
 
 script:
   - mkdir -p build/tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-dist
-  - travis_retry test $TRAVIS_PHP_VERSION == '7.1' && composer install --no-interaction --prefer-dist --dev scrutinizer/ocular
+  - test $TRAVIS_PHP_VERSION == '7.1' && travis_retry composer require --dev --no-interaction --prefer-dist scrutinizer/ocular || true
 
 script:
   - mkdir -p build/tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.1.4
+- Fix implementation of libxml use internal errors on `SchemaValidator::validate`
+- When creating the dom document avoid warnings (fix using the correct constant)
+- Avoid using versions `@stable` in `composer.json`
+
 # Version 1.1.3
 - Fix test were fialing on php 7.0 and 7.1
     - class PHPUnit_Framework_TestCase is deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fix implementation of libxml use internal errors on `SchemaValidator::validate`
 - When creating the dom document avoid warnings (fix using the correct constant)
 - Avoid using versions `@stable` in `composer.json`
+- Install scrutinizer/ocular only on travis and PHP 7.1
 
 # Version 1.1.3
 - Fix test were fialing on php 7.0 and 7.1

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # eclipxe13/xmlschemavalidator To Do
 
+- [ ] Deprecate PHP 5.6
 - [ ] Document usage examples
 - [ ] Move from standard exceptions to library exceptions
 - [ ] Use better XSD samples, currently is heavely related to Mexico SAT CFDI v 3.2

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # eclipxe13/xmlschemavalidator To Do
 
-- [ ] Deprecate PHP 5.6
+- [ ] Deprecate PHP 5.6 to PHP 7.0 and phpunit from ^5.7 to ^6.3
 - [ ] Document usage examples
 - [ ] Move from standard exceptions to library exceptions
 - [ ] Use better XSD samples, currently is heavely related to Mexico SAT CFDI v 3.2

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "@stable",
-        "jakub-onderka/php-parallel-lint": "@stable",
-        "squizlabs/php_codesniffer": "@stable",
-        "friendsofphp/php-cs-fixer": "@stable",
-        "scrutinizer/ocular": "@stable"
+        "phpunit/phpunit": "^6.2",
+        "jakub-onderka/php-parallel-lint": "^0.9",
+        "squizlabs/php_codesniffer": "^3.0",
+        "friendsofphp/php-cs-fixer": "^2.4",
+        "scrutinizer/ocular": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "phpunit/phpunit": "^6.2",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.4",
-        "scrutinizer/ocular": "^1.3"
+        "friendsofphp/php-cs-fixer": "^2.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
+        "phpunit/phpunit": "^5.7",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4"

--- a/src/XmlSchemaValidator/SchemaValidator.php
+++ b/src/XmlSchemaValidator/SchemaValidator.php
@@ -52,7 +52,7 @@ class SchemaValidator
         }
 
         // input validation
-        if (! is_string($content) || $content === '') {
+        if (! is_string($content) || '' === $content) {
             throw new \InvalidArgumentException('The content to validate must be a non-empty string');
         }
 
@@ -83,8 +83,8 @@ class SchemaValidator
             }
         }
 
-        // return true
-        return ! $this->registerError('');
+        $this->registerError('');
+        return true;
     }
 
     /**

--- a/src/XmlSchemaValidator/SchemaValidator.php
+++ b/src/XmlSchemaValidator/SchemaValidator.php
@@ -61,7 +61,7 @@ class SchemaValidator
 
         // create the DOMDocument object
         $dom = new DOMDocument();
-        $dom->loadXML($content, LIBXML_ERR_ERROR);
+        $dom->loadXML($content, LIBXML_NOWARNING);
 
         // check for errors on load XML
         if (false !== $xmlerror = libxml_get_last_error()) {

--- a/src/XmlSchemaValidator/SchemaValidator.php
+++ b/src/XmlSchemaValidator/SchemaValidator.php
@@ -46,9 +46,11 @@ class SchemaValidator
     {
         // encapsulate the function inside libxml_use_internal_errors(true)
         if (true !== libxml_use_internal_errors(true)) {
-            $return = $this->validate($content);
-            libxml_use_internal_errors(false);
-            return $return;
+            try {
+                return $this->validate($content);
+            } finally {
+                libxml_use_internal_errors(false);
+            }
         }
 
         // input validation


### PR DESCRIPTION
- Fix implementation of libxml use internal errors on `SchemaValidator::validate`
- When creating the dom document avoid warnings (fix using the correct constant)
- Avoid using versions `@stable` in `composer.json`
- Install scrutinizer/ocular only on travis and PHP 7.1