### PR TITLE
Version 2.1.1 2020-01-08

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,7 +14,7 @@ build:
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-          - command: vendor/bin/phpunit --testdox --coverage-clover=coverage.clover
+          - command: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover
             coverage:
               file: coverage.clover
               format: clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 script:
   - vendor/bin/phpcs -sp src/ tests/
   - vendor/bin/php-cs-fixer fix --using-cache=no --dry-run --verbose
-  - vendor/bin/phpunit --testdox --verbose
+  - vendor/bin/phpunit --verbose
   - test $TRAVIS_PHP_VERSION != "7.0" && vendor/bin/phpstan analyse --no-progress --level max src/ tests/ || true
   - test $TRAVIS_PHP_VERSION != "7.0" && vendor/bin/psalm --no-progress || true
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# eclipxe/xmlschemavalidator To Do
+# eclipxe/XmlSchemaValidator To Do
 
 - [ ] Document usage examples
 

--- a/tests/XmlSchemaValidatorTests/LibXmlExceptionTest.php
+++ b/tests/XmlSchemaValidatorTests/LibXmlExceptionTest.php
@@ -42,7 +42,7 @@ final class LibXmlExceptionTest extends TestCase
         for ($previous = $foundException; null !== $previous; $previous = $previous->getPrevious()) {
             $chain[] = $previous->getMessage();
         }
-        $this->assertStringContainsString('Start tag expected', $foundException->getMessage());
+        $this->assertStringStartsWith('Start tag expected', $foundException->getMessage());
         $this->assertCount(1, $chain, 'It should only exists 1 error');
     }
 


### PR DESCRIPTION
- Improve testing, 100% code coverage, each test class uses cover related class.
- Improve Travis-CI, do not create code coverage.
- Improve Scrutinizer-CI, create code coverage.
- Change development dependence from `phpstan/phpstan-shim` to `phpstan/phpstan`.
- Remove development dependence `overtrue/phplint`.
- Remove SensioLabs Insight.
- Update documentation, licence, changelog, etc..