### PR TITLE
Version 3.0.2

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.7.0" installed="3.7.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpstan" version="^1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.20.0" installed="4.20.0" location="./tools/psalm" copy="false"/>
+  <phar name="phpstan" version="^1.4.8" installed="1.4.8" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.22.0" installed="4.22.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ try {
 ## Exceptions
 
 This library creates its own specific exceptions and all of them implements `XmlSchemaValidatorException`.
-Check the [exceptions documentation](docs/Exceptions.md) for more information.
+Check the [exceptions' documentation](docs/Exceptions.md) for more information.
 
 When this library uses LibXML functions, it captures the errors and throw its own exception.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ There are no unreleased changes.
 
 ## Version 3.0.2 2022-03-08
 
-Change return type on `Schemas::getIterator()` to include `Traversable`. This avoid compatibility issues with PHP 8.1.
+Change return type on `Schemas::getIterator()` to include `Traversable`. This avoids compatibility issues with PHP 8.1.
 
 Check `DOMAttr::nodeValue` can be `null`. Remove Psalm ignore.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ classes. The library will not export any of these objects outside its own scope.
 
 ## Unreleased changes
 
+There are no unreleased changes.
+
+## Version 3.0.2 2022-03-08
+
+Change return type on `Schemas::getIterator()` to include `Traversable`. This avoid compatibility issues with PHP 8.1.
+
+Check `DOMAttr::nodeValue` can be `null`. Remove Psalm ignore.
+
+Fix build, PHPStan ^1.4.7 does not recognize `DOMNodeList` element types. Change type to `iterable`.
+
+Update development tools to recent versions.
+
+This release includes Previous unreleased changes:
+
 - 2022-02-09: Fix broken CI.
 
 Remove unused code on test.

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -153,9 +153,11 @@ class SchemaValidator
         $schemasList = $xpath->query("//@$xsi:schemaLocation") ?: new DOMNodeList();
 
         // process every schemaLocation and import them into schemas
-        foreach ($schemasList as $node) {
-            /** @psalm-suppress PossiblyNullArgument */
-            $schemas->import($this->buildSchemasFromSchemaLocationValue($node->nodeValue));
+        foreach ($schemasList as $schemaAttribute) {
+            $schemaValue = $schemaAttribute->nodeValue;
+            if (null !== $schemaValue) {
+                $schemas->import($this->buildSchemasFromSchemaLocationValue($schemaValue));
+            }
         }
 
         return $schemas;

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -149,7 +149,7 @@ class SchemaValidator
         }
 
         // get all the xsi:schemaLocation attributes in the document
-        /** @var DOMNodeList<DOMAttr> $schemasList */
+        /** @var iterable<DOMAttr> $schemasList */
         $schemasList = $xpath->query("//@$xsi:schemaLocation") ?: new DOMNodeList();
 
         // process every schemaLocation and import them into schemas

--- a/src/Schemas.php
+++ b/src/Schemas.php
@@ -139,7 +139,7 @@ class Schemas implements IteratorAggregate, Countable
     }
 
     /** @return Traversable<string, Schema> */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->schemas);
     }


### PR DESCRIPTION
Change return type on `Schemas::getIterator()` to include `Traversable`. This avoid compatibility issues with PHP 8.1.

Check `DOMAttr::nodeValue` can be `null`. Remove Psalm ignore.

Fix build, PHPStan ^1.4.7 does not recognize `DOMNodeList` element types. Change type to `iterable`.

Update development tools to recent versions.