### PR TITLE
Maintenance 2022-07-18

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.7.0" installed="3.7.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpstan" version="^1.4.8" installed="1.4.8" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.22.0" installed="4.22.0" location="./tools/psalm" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.7.0" installed="3.9.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcbf" version="^3.6.2" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^3.6.2" installed="3.7.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpstan" version="^1.4.8" installed="1.8.1" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.22.0" installed="4.24.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,51 +1,51 @@
 <?php
 
+/**
+ * @noinspection PhpUndefinedClassInspection
+ * @noinspection PhpUndefinedNamespaceInspection
+ * @see https://cs.symfony.com/doc/ruleSets/
+ * @see https://cs.symfony.com/doc/rules/
+ */
+
 declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
-        '@PSR2' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
-        '@PHP71Migration' => true,
+        '@PSR12' => true,
+        '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         // symfony
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'no_alias_functions' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'self_accessor' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
-        // contrib
         'concat_space' => ['spacing' => 'one'],
-        'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
         'linebreak_after_opening_tag' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        // symfony:risky
+        'no_alias_functions' => true,
+        'self_accessor' => true,
+        // contrib
+        'not_operator_with_successor_space' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
+            ->append([__FILE__])
             ->exclude(['vendor', 'tools', 'build'])
     )
 ;

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,11 +9,14 @@ build:
       - composer upgrade --no-interaction --prefer-dist
   nodes:
     analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
+      environment:
+        php:
+          version: 7.4
       project_setup: { override: true }
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-          - command: vendor/bin/phpunit --verbose --testdox --coverage-clover=coverage.clover
+          - command: php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --testdox --coverage-clover=coverage.clover
             coverage:
               file: coverage.clover
               format: clover

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ but it will not be active maintained. You should change your dependency as soon 
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING][] for details
-and don't forget to take a look in the [TODO][] and [CHANGELOG][] files.
+and don't forget to take a look in [TODO][] and [CHANGELOG][] files.
 
 ## Copyright and License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,13 @@ classes. The library will not export any of these objects outside its own scope.
 
 ## Unreleased changes
 
-There are no unreleased changes.
+### Unreleased 2022-07-18
+
+This is a maintenance update.
+
+- Fix code style.
+- Update `php-cs-fixer` config file to recent rules.
+- Update development tools.
 
 ## Version 3.0.2 2022-03-08
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a maintenance update.
 - Fix code style.
 - Update `php-cs-fixer` config file to recent rules.
 - Update development tools.
+- Update Scrutinizer CI to run on PHP 7.4.
 
 ## Version 3.0.2 2022-03-08
 

--- a/tests/Unit/SchemaTest.php
+++ b/tests/Unit/SchemaTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Eclipxe\XmlSchemaValidator\Tests\Unit;
 
- use Eclipxe\XmlSchemaValidator\Schema;
- use Eclipxe\XmlSchemaValidator\Tests\TestCase;
+use Eclipxe\XmlSchemaValidator\Schema;
+use Eclipxe\XmlSchemaValidator\Tests\TestCase;
 
- /** @covers \Eclipxe\XmlSchemaValidator\Schema */
+/** @covers \Eclipxe\XmlSchemaValidator\Schema */
 final class SchemaTest extends TestCase
 {
     public function testCreateObjectAndReadProperties(): void


### PR DESCRIPTION
This is a maintenance update. No release as a new version.

- Fix code style.
- Update `php-cs-fixer` config file to recent rules.
- Update development tools.
- Update Scrutinizer CI to run on PHP 7.4.
