### PR TITLE
Maintenance 2022-12-08

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,6 @@
 /phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
 /psalm.xml                  export-ignore
+
+# Do not count these files on github code language
+/tests/_files/**            linguist-detectable=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Coding standards (phpcs)
@@ -33,13 +33,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Coding standards (php-cs-fixer)
@@ -50,10 +50,10 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -64,9 +64,9 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -81,20 +81,20 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, phpstan
         env:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -109,26 +109,28 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, psalm
         env:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Show psalm version
+        run: psalm --version
       - name: Static analysis (psalm)
         run: psalm --no-progress
 
@@ -137,20 +139,20 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: xdebug
           tools: composer:v2, infection
         env:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.7.0" installed="3.9.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.7.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
   <phar name="phpcs" version="^3.6.2" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpstan" version="^1.4.8" installed="1.8.1" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.22.0" installed="4.24.0" location="./tools/psalm" copy="false"/>
+  <phar name="phpstan" version="^1.4.8" installed="1.9.2" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.1.0" installed="5.1.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,17 +18,17 @@ return (new PhpCsFixer\Config())
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         // symfony
-        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -41,6 +41,7 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,8 @@
 filter:
+  dependency_paths:
+    - 'vendor/'
   excluded_paths:
     - 'tests/'
-    - 'vendor/'
 
 build:
   dependencies:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ This is a maintenance update that fixes continuous integration.
 - Update development tools.
 - Exclude linguist detection on `tests/_files`.
 - Update code styles rules as other projects.
+- Implement `dependency_paths` on Scrutinizer-CI.
 
 ### Unreleased 2022-07-18
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,23 @@ classes. The library will not export any of these objects outside its own scope.
 
 ## Unreleased changes
 
+### Unreleased 2022-12-08
+
+This is a maintenance update that fixes continuous integration.
+
+- Fix Psalm analysis when evaluate that `DOMXPath::query()` return *falsy*.
+  It actually cannot return `false`, the expression is never malformed or the contextNode is never invalid.
+- Maintenance to GitHub workflow for continuous integration.
+  - Add PHP 8.2 to phpunit job matrix
+  - Update GitHub actions to version 3
+  - Run jobs on PHP 8.1
+  - Replace `echo ::set-output` deprecated instruction
+  - Remove composer installation where is not required
+  - Show Psalm version (it was not visible)
+- Update development tools.
+- Exclude linguist detection on `tests/_files`.
+- Update code styles rules as other projects.
+
 ### Unreleased 2022-07-18
 
 This is a maintenance update.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,7 +94,7 @@ Development environment:
 
 ## Version 3.0.0 2020-04-08
 
-- Lot of breacking changes has been made, see [upgrade from version `2.x` to `3.x`](UPGRADE-v2-v3.md).
+- Lot of breaking changes has been made, see [upgrade from version `2.x` to `3.x`](UPGRADE-v2-v3.md).
 - Namespace change from `\XmlSchemaValidator` to `\Eclipxe\XmlSchemaValidator`.
 - Now uses named exceptions, see [exceptions documentation](Exceptions.md).
 - Minimal PHP version is PHP 7.3.
@@ -122,7 +122,7 @@ Development environment:
 
 - Allow to create a `SchemaValidator` instance using `DOMDocument`
 - Run PHPUnit 7 on PHP >= 7.1
-- Run phpstan 0.10/0.11 on PHP >= 7.1
+- Run PHPStan 0.10/0.11 on PHP >= 7.1
 
 ## Version 2.0.2
 
@@ -133,10 +133,10 @@ Development environment:
 
 ## Version 2.0.1
 
-- Fix bug when using windows path (backslashs), it does not validate
+- Fix bug when using windows path (backslashes), it does not validate
 - Add docblock to buildSchemas
-- Improve building, add phpstan
-- Use phplint instead of php-parallel-lint
+- Improve building, add PHPStan
+- Use PHPLint instead of php-parallel-lint
 - Update dependencies using composer-require-checker
 
 ## Version 2.0.0
@@ -149,7 +149,7 @@ Development environment:
 - Add new method `SchemaValidator::validateWithSchemas` that do the same
   thing as `SchemaValidator::validate` but you must provide the `Schemas` collection
 - Change from `protected` to `public` the method `SchemaValidator::buildSchemas`,
-  it's usefull when used with `SchemaValidator::validateWithSchemas` to change
+  it's useful when used with `SchemaValidator::validateWithSchemas` to change
   XSD remote locations to local or other places.
 - Add `XmlSchemaValidator::LibXmlException`. It contains a method to exec a callable
   isolating the use internal errors setting and other to collect libxml errors
@@ -169,7 +169,7 @@ Development environment:
 
 ## Version 1.1.3
 
-- Fix test were fialing on php 7.0 and 7.1
+- Fix test were failing on php 7.0 and 7.1
     - class PHPUnit_Framework_TestCase is deprecated
     - wait for 0.5 seconds after run the php server
 
@@ -196,12 +196,12 @@ Development environment:
 - Tests
     - Add tests for the Locator constructor and downloader getter.
     - Add tests for `XmlSchemaValidator\Downloader`
-    - Start php internal server to run tests on downloaders (bootstrap.php)
+    - Start php internal server to run tests on downloader (bootstrap.php)
     - Default tests for locator uses a faker test to avoid external downloads
 - Continuous Integration
     - Add 7.1
     - Drop hhvm
-- Standarization
+- Standardization
     - Rename folder `sources` to `src`
     - Rename `.php_cs` to `.php_cs.dist` require dev `friendsofphp/php-cs-fixer`
     - Add `phpcs.xml.dist`
@@ -214,6 +214,6 @@ Development environment:
 
 ## Version 1.0.0
 
-- Follow recommendations from sensiolabs
+- Follow recommendations from SensioLabs
 - Project does not depends on zip extension
 - Include SensioLabs Insight

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>src</file>
     <file>tests</file>
@@ -9,8 +9,9 @@
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
+    <arg name="cache" value="build/phpcs.cache"/>
 
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/src/Internal/LibXmlException.php
+++ b/src/Internal/LibXmlException.php
@@ -10,7 +10,7 @@ use LibXMLError;
 
 class LibXmlException extends Exception
 {
-    private const ERROR_LEVEL_SUPRESS_ALL = 0;
+    private const ERROR_LEVEL_SUPPRESS_ALL = 0;
 
     /** @var LibXMLError[] */
     private $errors;
@@ -93,7 +93,7 @@ class LibXmlException extends Exception
     public static function useInternalErrors(callable $callable)
     {
         // capture current error reporting level and set to no-errors
-        $previousErrorReporting = error_reporting(self::ERROR_LEVEL_SUPRESS_ALL);
+        $previousErrorReporting = error_reporting(self::ERROR_LEVEL_SUPPRESS_ALL);
 
         // capture current libxml use internal errors and set to true
         $previousLibXmlUseInternalErrors = libxml_use_internal_errors(true);

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -6,7 +6,6 @@ namespace Eclipxe\XmlSchemaValidator;
 
 use DOMAttr;
 use DOMDocument;
-use DOMNodeList;
 use DOMXPath;
 use Eclipxe\XmlSchemaValidator\Exceptions\SchemaLocationPartsNotEvenException;
 use Eclipxe\XmlSchemaValidator\Exceptions\ValidationFailException;
@@ -150,7 +149,7 @@ class SchemaValidator
 
         // get all the xsi:schemaLocation attributes in the document
         /** @var iterable<DOMAttr> $schemasList */
-        $schemasList = $xpath->query("//@$xsi:schemaLocation") ?: new DOMNodeList();
+        $schemasList = $xpath->query("//@$xsi:schemaLocation");
 
         // process every schemaLocation and import them into schemas
         foreach ($schemasList as $schemaAttribute) {

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -37,7 +37,7 @@ class SchemaValidator
     }
 
     /**
-     * Create a SchemaValidator instance based on a XML string
+     * Create a SchemaValidator instance based on an XML string
      *
      * @param string $contents
      * @return self

--- a/src/Schemas.php
+++ b/src/Schemas.php
@@ -19,7 +19,7 @@ use Traversable;
  */
 class Schemas implements IteratorAggregate, Countable
 {
-    /** @var array<string, Schema> intenal collection of schemas */
+    /** @var array<string, Schema> internal collection of schemas */
     private $schemas = [];
 
     /**
@@ -114,10 +114,10 @@ class Schemas implements IteratorAggregate, Countable
     }
 
     /**
-     * Get an schema object by its namespace
+     * Get a schema object by its namespace
      *
      * @param string $namespace
-     * @throws NamespaceNotFoundInSchemas when namespace does not exists on schema
+     * @throws NamespaceNotFoundInSchemas when namespace does not exist on schema
      * @return Schema
      */
     public function item(string $namespace): Schema

--- a/src/Schemas.php
+++ b/src/Schemas.php
@@ -27,6 +27,7 @@ class Schemas implements IteratorAggregate, Countable
      * with the local location
      *
      * @return string
+     * @noinspection PhpDocMissingThrowsInspection
      */
     public function getImporterXsd(): string
     {
@@ -35,6 +36,7 @@ class Schemas implements IteratorAggregate, Countable
         /** @var DOMElement $document */
         $document = $xsd->documentElement;
         foreach ($this->schemas as $schema) {
+            /** @noinspection PhpUnhandledExceptionInspection */
             $node = $xsd->createElementNS('http://www.w3.org/2001/XMLSchema', 'import');
             $node->setAttribute('namespace', $schema->getNamespace());
             $node->setAttribute('schemaLocation', str_replace('\\', '/', $schema->getLocation()));


### PR DESCRIPTION
This is a maintenance update that fixes continuous integration.

- Fix Psalm analysis when evaluate that `DOMXPath::query()` return *falsy*.
  It actually cannot return `false`, the expression is never malformed or the contextNode is never invalid.
- Maintenance to GitHub workflow for continuous integration.
  - Add PHP 8.2 to phpunit job matrix
  - Update GitHub actions to version 3
  - Run jobs on PHP 8.1
  - Replace `echo ::set-output` deprecated instruction
  - Remove composer installation where is not required
  - Show Psalm version (it was not visible)
- Update development tools.
- Exclude linguist detection on `tests/_files`.
- Update code styles rules as other projects.