### PR TITLE
Fix split schemaValidator into parts

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -36,6 +36,7 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,22 @@ classes. The library will not export any of these objects outside its own scope.
 
 ## Unreleased changes
 
+Unreleased changes will be listed here.
+
+## Version 3.0.3 2022-12-19
+
+When split the content of a *schema location* value, must reindex the list of values.
+The following code wasn't interpreted correctly:
+
+```xml
+<r xsi:schemaLocation="
+    http://test.org/schemas/ticket
+    http://localhost:8999/xsd/ticket.xsd
+    "/>
+```
+
+See <https://github.com/eclipxe13/XmlSchemaValidator/issues/14>. Thanks `@brankopetric`.
+
 ### Unreleased 2022-12-08
 
 This is a maintenance update that fixes continuous integration.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,10 @@ The following code wasn't interpreted correctly:
 
 See <https://github.com/eclipxe13/XmlSchemaValidator/issues/14>. Thanks `@brankopetric`.
 
+### Development changes
+
+- Add `fully_qualified_strict_types` rule to `php-cs-fixer` tool.
+
 ### Unreleased 2022-12-08
 
 This is a maintenance update that fixes continuous integration.

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -172,7 +172,7 @@ class SchemaValidator
     public function buildSchemasFromSchemaLocationValue(string $content): Schemas
     {
         // get parts without inner spaces
-        $parts = array_filter(preg_split('/\s+/', $content) ?: []);
+        $parts = array_values(array_filter(preg_split('/\s+/', $content) ?: []));
         $partsCount = count($parts);
 
         // check that the list count is an even number

--- a/tests/Unit/SchemaValidatorTest.php
+++ b/tests/Unit/SchemaValidatorTest.php
@@ -208,4 +208,27 @@ final class SchemaValidatorTest extends TestCase
         }
         $this->assertSame($expectedParts, $retrievedParts);
     }
+
+    public function testBuildSchemasFromSchemaLocationValueWithLeadingAndTrailingWhiteSpace(): void
+    {
+        /** @see https://github.com/eclipxe13/XmlSchemaValidator/issues/14 */
+        // this line contains leading and trailing whitespace simulating the contents of a multiline attribute content
+        $schemaLocationValue = <<< EOXML
+
+                uri:foo
+                foo.xsd
+                uri:bar
+                bar.xsd
+
+            EOXML;
+        $expected = 'uri:foo foo.xsd uri:bar bar.xsd';
+
+        $validator = SchemaValidator::createFromString('<x/>');
+        $schemas = $validator->buildSchemasFromSchemaLocationValue($schemaLocationValue);
+        $retrieved = implode(' ', array_map(function (Schema $schema): string {
+            return $schema->getNamespace() . ' ' . $schema->getLocation();
+        }, iterator_to_array($schemas)));
+
+        $this->assertSame($expected, $retrieved);
+    }
 }


### PR DESCRIPTION
When split the content of a *schema location* value, must reindex the list of values. The following code wasn't interpreted correctly:

```xml
<r xsi:schemaLocation="
    http://test.org/schemas/ticket
    http://localhost:8999/xsd/ticket.xsd
    "/>
```

Closes #14.
Thanks @brankopetric.

- Add `fully_qualified_strict_types` rule to `php-cs-fixer` tool.