### PR TITLE
Fix build by solving Psalm issues (version 3.0.3)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[docker-compose.yml]
+indent_size = 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         run: vendor/bin/phpunit --testdox --verbose
 
   phpstan:
-    name: Static analysis (phpstan)
+    name: Code analysis (phpstan)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -101,11 +101,11 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-      - name: Static analysis (phpstan)
+      - name: Code analysis (phpstan)
         run: phpstan analyse --no-progress --verbose
 
   psalm:
-    name: Static analysis (psalm)
+    name: Code analysis (psalm)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -131,7 +131,7 @@ jobs:
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Show psalm version
         run: psalm --version
-      - name: Static analysis (psalm)
+      - name: Code analysis (psalm)
         run: psalm --no-progress
 
   infection:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -53,7 +53,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -66,7 +66,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -81,7 +81,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -94,7 +94,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -109,7 +109,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -122,7 +122,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -139,7 +139,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -152,7 +152,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -85,7 +85,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -113,7 +113,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, psalm
         env:
@@ -143,7 +143,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: xdebug
           tools: composer:v2, infection
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,18 +46,18 @@ jobs:
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
   phpunit:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.7.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpcs" version="^3.6.2" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpstan" version="^1.4.8" installed="1.9.2" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^5.1.0" installed="5.1.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.51.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcbf" version="^3.9.0" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^3.9.0" installed="3.9.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpstan" version="^1.10.60" installed="1.10.60" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.22.2" installed="5.22.2" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.27.10" installed="0.27.10" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,11 +3,12 @@ filter:
     - 'vendor/'
   excluded_paths:
     - 'tests/'
+    - 'tools/'
 
 build:
   dependencies:
     override:
-      - composer upgrade --no-interaction --prefer-dist
+      - composer update --no-interaction --no-progress --prefer-dist
   nodes:
     analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
       environment:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2022 Carlos C Soto
+Copyright (c) 2016 - 2024 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ When split the content of a *schema location* value, must reindex the list of va
 The following code wasn't interpreted correctly:
 
 ```xml
+
 <r xsi:schemaLocation="
     http://test.org/schemas/ticket
     http://localhost:8999/xsd/ticket.xsd
@@ -47,12 +48,12 @@ This is a maintenance update that fixes continuous integration.
 - Fix Psalm analysis when evaluate that `DOMXPath::query()` return *falsy*.
   It actually cannot return `false`, the expression is never malformed or the contextNode is never invalid.
 - Maintenance to GitHub workflow for continuous integration.
-  - Add PHP 8.2 to phpunit job matrix
-  - Update GitHub actions to version 3
-  - Run jobs on PHP 8.1
-  - Replace `echo ::set-output` deprecated instruction
-  - Remove composer installation where is not required
-  - Show Psalm version (it was not visible)
+    - Add PHP 8.2 to phpunit job matrix
+    - Update GitHub actions to version 3
+    - Run jobs on PHP 8.1
+    - Replace `echo ::set-output` deprecated instruction
+    - Remove composer installation where is not required
+    - Show Psalm version (it was not visible)
 - Update development tools.
 - Exclude linguist detection on `tests/_files`.
 - Update code styles rules as other projects.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,19 @@ classes. The library will not export any of these objects outside its own scope.
 
 Unreleased changes will be listed here.
 
+## Version 3.0.4 2024-03-08
+
+- Fix falsy comparisons (Psalm).
+- Update license year to 2024.
+- Update coding standards.
+- Improve GitHub workflow:
+    - Add PHP 8.3 to test matrix.
+    - Run jobs using PHP 8.3.
+    - Update GitHub actions to version 4.
+    - Update code analysis titles.
+    - Rename matrix variable name php-version (singular).
+- Update development tools.
+
 ## Version 3.0.3 2022-12-19
 
 When split the content of a *schema location* value, must reindex the list of values.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,15 +1,15 @@
-<?xml version="1.0"?>
-<ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-12 based) coding standard.</description>
-
-    <file>src</file>
-    <file>tests</file>
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Personal">
+    <description>Personal coding standard.</description>
 
     <arg name="tab-width" value="4"/>
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
     <arg name="cache" value="build/phpcs.cache"/>
+
+    <file>src/</file>
+    <file>tests/</file>
 
     <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>

--- a/src/SchemaValidator.php
+++ b/src/SchemaValidator.php
@@ -142,8 +142,8 @@ class SchemaValidator
         $xpath = new DOMXPath($this->document);
 
         // get the http://www.w3.org/2001/XMLSchema-instance namespace (it could not be 'xsi')
-        $xsi = $this->document->lookupPrefix('http://www.w3.org/2001/XMLSchema-instance');
-        if (! $xsi) { // the namespace is not registered, no need to continue
+        $xsi = strval($this->document->lookupPrefix('http://www.w3.org/2001/XMLSchema-instance'));
+        if ('' === $xsi) { // the namespace is not registered, no need to continue
             return $schemas;
         }
 

--- a/src/Schemas.php
+++ b/src/Schemas.php
@@ -42,7 +42,7 @@ class Schemas implements IteratorAggregate, Countable
             $node->setAttribute('schemaLocation', str_replace('\\', '/', $schema->getLocation()));
             $document->appendChild($node);
         }
-        return $xsd->saveXML() ?: '';
+        return strval($xsd->saveXML());
     }
 
     /**

--- a/tests/Unit/SchemaValidatorTest.php
+++ b/tests/Unit/SchemaValidatorTest.php
@@ -186,6 +186,17 @@ final class SchemaValidatorTest extends TestCase
         $this->assertSame($expected, $retrieved);
     }
 
+    public function testBuildSchemasWithoutXmlSchemaDefinition(): void
+    {
+        $content = <<< XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <root />
+            XML;
+        $validator = SchemaValidator::createFromString($content);
+        $schemas = $validator->buildSchemas();
+        $this->assertSame([], $schemas->all());
+    }
+
     public function testBuildSchemasFromSchemaLocationValue(): void
     {
         $validator = $this->utilCreateValidator('books-valid.xml');


### PR DESCRIPTION
- Fix falsy comparisons (Psalm).
- Update license year to 2024.
- Update coding standards.
- Improve GitHub workflow:
    - Add PHP 8.3 to test matrix.
    - Run jobs using PHP 8.3.
    - Update GitHub actions to version 4.
    - Update code analysis titles.
    - Rename matrix variable name php-version (singular).
- Update development tools.
