### PR TITLE
Maintenance 2025-02-18 (version Version 3.0.5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -86,7 +86,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,36 +105,6 @@ jobs:
       - name: Code analysis (phpstan)
         run: phpstan analyse --no-progress --verbose
 
-  psalm:
-    name: Code analysis (psalm)
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          coverage: none
-          tools: composer:v2, psalm
-        env:
-          fail-fast: true
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Install project dependencies
-        run: composer upgrade --no-interaction --no-progress --prefer-dist
-      - name: Show psalm version
-        run: psalm --version
-      - name: Code analysis (psalm)
-        run: psalm --no-progress
-
   infection:
     name: Mutation Testing (infection)
     runs-on: "ubuntu-latest"

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -4,6 +4,5 @@
   <phar name="phpcbf" version="^3.11.3" installed="3.11.3" location="./tools/phpcbf" copy="false"/>
   <phar name="phpcs" version="^3.11.3" installed="3.11.3" location="./tools/phpcs" copy="false"/>
   <phar name="phpstan" version="^2.1.5" installed="2.1.5" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^5.22.2" installed="5.22.2" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.29.11" installed="0.29.11" location="./tools/infection" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.51.0" installed="3.51.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcbf" version="^3.9.0" installed="3.9.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpcs" version="^3.9.0" installed="3.9.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpstan" version="^1.10.60" installed="1.10.60" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.69.0" installed="3.69.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcbf" version="^3.11.3" installed="3.11.3" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^3.11.3" installed="3.11.3" location="./tools/phpcs" copy="false"/>
+  <phar name="phpstan" version="^2.1.5" installed="2.1.5" location="./tools/phpstan" copy="false"/>
   <phar name="psalm" version="^5.22.2" installed="5.22.2" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.27.10" installed="0.27.10" location="./tools/infection" copy="false"/>
+  <phar name="infection" version="^0.29.11" installed="0.29.11" location="./tools/infection" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2024 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2016 - 2025 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ try {
 }
 ```
 
+On previous example, the class `LibXmlException` is *internal*.
+It will be *public (not internal)* on next major release.
+
 ## Exceptions
 
 This library creates its own specific exceptions and all of them implements `XmlSchemaValidatorException`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ declare(strict_types=1);
 
 use Eclipxe\XmlSchemaValidator\SchemaValidator;
 use Eclipxe\XmlSchemaValidator\Exceptions\ValidationFailException;
+use Eclipxe\XmlSchemaValidator\Internal\LibXmlException;
 
 // create SchemaValidator using a DOMDocument
 $document = new DOMDocument();
@@ -62,6 +63,13 @@ try {
     $validator->validateWithSchemas($schemas);
 } catch (ValidationFailException $ex) {
     echo 'Found error: ' . $ex->getMessage();
+    $previous = $ex->getPrevious();
+    if ($previous instanceof LibXmlException) {
+        foreach ($previous->getErrors() as $libXmlError) {
+            echo $libXmlError->message, PHP_EOL,
+                'File: ', $libXmlError->file, ':', $libXmlError->line, ',', $libXmlError->column, PHP_EOL;
+        }
+    }
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
             "@dev:check-style",
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
             "@php tools/phpstan analyse --no-progress",
-            "@php tools/psalm --no-progress",
             "@dev:infection"
         ],
         "dev:coverage": [
@@ -61,7 +60,7 @@
         "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:fix-style, dev:check-style, phpunit, phpstan, psalm and infection",
+        "dev:test": "DEV: run dev:fix-style, dev:check-style, phpunit, phpstan and infection",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
         "dev:infection": "DEV: run mutation tests using infection"
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased changes will be listed here.
 
 ## Version 3.0.5 2025-02-18
 
+- Fix `ValidationFailException` signature for compatibility with PHP 8.4.
 - Update license year to 2025.
 - Remove Psalm, only use PHPStan.
 - Add PHP 8.4 to test matrix.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ classes. The library will not export any of these objects outside its own scope.
 
 Unreleased changes will be listed here.
 
+## Version 3.0.5 2025-02-18
+
+- Update license year to 2025.
+
 ## Version 3.0.4 2024-03-08
 
 - Fix falsy comparisons (Psalm).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ Unreleased changes will be listed here.
 - Update license year to 2025.
 - Remove Psalm, only use PHPStan.
 - Add PHP 8.4 to test matrix.
-- Run phpcs and phpstan on PHP 8.4.
+- Run `phpcs` and `phpstan` on PHP 8.4.
 - Update development tools.
 
 ## Version 3.0.4 2024-03-08
@@ -161,7 +161,7 @@ Development environment:
 - Change development dependence from `phpstan/phpstan-shim` to `phpstan/phpstan`.
 - Remove development dependence `overtrue/phplint`.
 - Remove SensioLabs Insight.
-- Update documentation, licence, changelog, etc..
+- Update documentation, licence, changelog, etc.
 
 ## Version 2.1.0
 
@@ -260,5 +260,5 @@ Development environment:
 ## Version 1.0.0
 
 - Follow recommendations from SensioLabs
-- Project does not depends on zip extension
+- Project does not depend on zip extension
 - Include SensioLabs Insight

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased changes will be listed here.
 ## Version 3.0.5 2025-02-18
 
 - Fix `ValidationFailException` signature for compatibility with PHP 8.4.
+- Add example on how to load `libxml` errors.
 - Update license year to 2025.
 - Remove Psalm, only use PHPStan.
 - Add PHP 8.4 to test matrix.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased changes will be listed here.
 
 - Update license year to 2025.
 - Remove Psalm, only use PHPStan.
+- Add PHP 8.4 to test matrix.
 - Update development tools.
 
 ## Version 3.0.4 2024-03-08

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Unreleased changes will be listed here.
 - Update license year to 2025.
 - Remove Psalm, only use PHPStan.
 - Add PHP 8.4 to test matrix.
+- Run phpcs and phpstan on PHP 8.4.
 - Update development tools.
 
 ## Version 3.0.4 2024-03-08

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased changes will be listed here.
 ## Version 3.0.5 2025-02-18
 
 - Update license year to 2025.
+- Remove Psalm, only use PHPStan.
+- Update development tools.
 
 ## Version 3.0.4 2024-03-08
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,6 +4,10 @@
   see <https://www.w3.org/TR/xmlschema11-1/#xsi_schemaLocation>
   and <https://www.w3.org/TR/xmlschema11-1/#schema-loc>
 
+- `LibXmlException` should not be internal and move to `Exceptions`.
+
+- `ValidationFailException` could have a method to access `LibXmlError` list of previous `LibXmlException`.
+
 ## Completed on version 3.0
 
 - [X] Move sources to namespace `Eclipxe\XmlSchemaValidator`

--- a/src/Exceptions/ValidationFailException.php
+++ b/src/Exceptions/ValidationFailException.php
@@ -11,7 +11,7 @@ final class ValidationFailException extends RuntimeException implements XmlSchem
 {
     private const EXCODE_NIL = 0;
 
-    private function __construct(string $message, Throwable $previous = null)
+    private function __construct(string $message, ?Throwable $previous = null)
     {
         parent::__construct($message, self::EXCODE_NIL, $previous);
     }

--- a/tests/Unit/Internal/LibXmlExceptionTest.php
+++ b/tests/Unit/Internal/LibXmlExceptionTest.php
@@ -25,7 +25,7 @@ final class LibXmlExceptionTest extends TestCase
     public function testConstructorWithNonLibXmlError(): void
     {
         /** @var LibXMLError[] $errors */
-        $errors = ['x-index' => (object) []];
+        $errors = ['x-index' => (object) []]; /** @phpstan-ignore-line */
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Error index x-index is not a LibXmlError');
         LibXmlException::create('foo', $errors);

--- a/tests/Unit/SchemaValidatorTest.php
+++ b/tests/Unit/SchemaValidatorTest.php
@@ -33,7 +33,8 @@ final class SchemaValidatorTest extends TestCase
         $document = new DOMDocument();
         $document->load($this->utilAssetLocation('books-valid.xml'));
         /** @noinspection PhpExpressionResultUnusedInspection */
-        new SchemaValidator($document);
+        new SchemaValidator($document); /** @phpstan-ignore-line */
+        /** @phpstan-ignore-next-line */
         $this->assertTrue(true, 'Expected no exception creating the schema validator using a DOMDocument');
     }
 
@@ -141,7 +142,7 @@ final class SchemaValidatorTest extends TestCase
         $schemas = new Schemas();
         $schemas->create('http://test.org/schemas/books', 'http://localhost:8999/xsd/books.xsd');
         $validator->validateWithSchemas($schemas);
-        $this->assertTrue(true, 'validateWithSchemas did not throw any exception');
+        $this->assertTrue(true, 'validateWithSchemas did not throw any exception'); /** @phpstan-ignore-line */
     }
 
     public function testValidateWithSchemasUsingLocal(): void
@@ -153,7 +154,7 @@ final class SchemaValidatorTest extends TestCase
             str_replace('/', '\\', dirname(__DIR__)) . '/public/xsd/books.xsd' // simulate windows path
         );
         $validator->validateWithSchemas($schemas);
-        $this->assertTrue(true, 'validateWithSchemas did not throw any exception');
+        $this->assertTrue(true, 'validateWithSchemas did not throw any exception'); /** @phpstan-ignore-line */
     }
 
     public function testValidateWithEmptySchema(): void


### PR DESCRIPTION
- Fix `ValidationFailException` signature for compatibility with PHP 8.4.
- Add example on how to load `libxml` errors.
- Update license year to 2025.
- Remove Psalm, only use PHPStan.
- Add PHP 8.4 to test matrix.
- Run `phpcs` and `phpstan` on PHP 8.4.
- Update development tools.